### PR TITLE
fix underscores in name

### DIFF
--- a/json2xlsx/utilities/json2xlsx.py
+++ b/json2xlsx/utilities/json2xlsx.py
@@ -423,7 +423,7 @@ def main_real():
                 render(workbook, cursor, y_size, x_size, render_state, [render_state['current_table']])
                 render_state['header_needed'] = False
             if node_type == 'load':
-                load_from_json_file_and_render(node['filename'], node['caption'], node['linebyline'] != None)
+                load_from_json_file_and_render(node['filename'], node['caption'], node['line_by_line'] != None)
             elif node_type == 'loadcsv':
                 load_from_csv_file_and_render(node['filename'], node['column_order'], node['caption'], node['has_header'])
         elif node_type == 'save':


### PR DESCRIPTION
I was getting an error when loading json in a tablescript file as described in the README.

It seems to be a typo, `node['linebyline']` works as `node['line_by_line']`.